### PR TITLE
Make search pluggable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /tmp/*
 /spec/example_app/tmp/*
 pkg
+.byebug_history
+gemfiles/.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
+  gem "rails-controller-testing"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,10 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.4.2)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -269,6 +273,7 @@ DEPENDENCIES
   poltergeist
   pry-rails
   rack-timeout
+  rails-controller-testing
   rails_stdout_logging
   redcarpet
   rspec-rails (~> 3.5.0)
@@ -280,4 +285,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/Rakefile
+++ b/Rakefile
@@ -24,8 +24,12 @@ task default: [:spec]
 
 if defined? RSpec
   task(:spec).clear
-  RSpec::Core::RakeTask.new(:spec) do |t|
+  RSpec::Core::RakeTask.new(:spec, :tag) do |t, task_args|
     t.verbose = false
+    t.rspec_opts ||= ""
+    if task_args[:tag]
+      t.rspec_opts += "--tag #{task_args[:tag]}"
+    end
   end
 end
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -16,7 +16,7 @@ gem "activerecord", "~> 4.2.0"
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"
-  gem "bundler-audit", :require => false
+  gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"
@@ -31,7 +31,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "shoulda-matchers", "~> 2.8.0", :require => false
+  gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"
 end
@@ -42,4 +42,4 @@ group :staging, :production do
   gem "uglifier"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -17,7 +17,7 @@ gem "rails-controller-testing"
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"
-  gem "bundler-audit", :require => false
+  gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"
@@ -32,7 +32,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "shoulda-matchers", "~> 2.8.0", :require => false
+  gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"
 end
@@ -43,4 +43,4 @@ group :staging, :production do
   gem "uglifier"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "administrate-field-image"
 gem "autoprefixer-rails"
-gem "bourbon", "~> 5.0.0.beta.7"
 gem "faker"
 gem "pg"
 gem "redcarpet"
@@ -18,7 +17,7 @@ gem "rails-controller-testing"
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"
-  gem "bundler-audit", :require => false
+  gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"
@@ -33,7 +32,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "shoulda-matchers", "~> 2.8.0", :require => false
+  gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"
 end
@@ -44,4 +43,4 @@ group :staging, :production do
   gem "uglifier"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -15,7 +15,7 @@ gem "rails-controller-testing"
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"
-  gem "bundler-audit", :require => false
+  gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"
@@ -30,7 +30,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "shoulda-matchers", "~> 2.8.0", :require => false
+  gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"
 end
@@ -41,4 +41,4 @@ group :staging, :production do
   gem "uglifier"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/administrate/default_search.rb
+++ b/lib/administrate/default_search.rb
@@ -1,0 +1,31 @@
+class DefaultSearch
+  def self.with_context(term)
+    self.new(term: term)
+  end
+
+  def initialize(term:)
+    @term = Array(term).flatten
+  end
+
+  def query(table_name, attr_name)
+    query = [build_query(table_name, attr_name)] * @term.size
+    query.join(" OR ")
+  end
+
+  def search_term
+    @term.map { |term| build_search_value(term) }
+  end
+
+  def with_context(term)
+    self.class.with_context(term)
+  end
+
+  protected
+  def build_query(table_name, attr_name)
+    "LOWER(#{table_name}.#{attr_name}) LIKE ?"
+  end
+
+  def build_search_value(term)
+    "%#{term.mb_chars.downcase}%"
+  end
+end

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -1,9 +1,12 @@
+require_relative "default_search"
 require_relative "deferred"
 require "active_support/core_ext/string/inflections"
 
 module Administrate
   module Field
     class Base
+      DEFAUT_SEARCH_IMPL = DefaultSearch.new
+
       def self.with_options(options = {})
         Deferred.new(self, options)
       end
@@ -14,6 +17,10 @@ module Administrate
 
       def self.searchable?
         false
+      end
+
+      def self.searchable
+        nil
       end
 
       def initialize(attribute, data, page, options = {})

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -1,11 +1,11 @@
-require_relative "default_search"
+require_relative "../default_search"
 require_relative "deferred"
 require "active_support/core_ext/string/inflections"
 
 module Administrate
   module Field
     class Base
-      DEFAUT_SEARCH_IMPL = DefaultSearch.new
+      DEFAUT_SEARCH_IMPL = DefaultSearch
 
       def self.with_options(options = {})
         Deferred.new(self, options)

--- a/lib/administrate/field/default_search.rb
+++ b/lib/administrate/field/default_search.rb
@@ -1,0 +1,9 @@
+class DefaultSearch
+  def query(table_name, attr_name)
+    "lower(#{table_name}.#{attr_name}) LIKE ?"
+  end
+
+  def search_term(term)
+    "%#{term.downcase}%"
+  end
+end

--- a/lib/administrate/field/default_search.rb
+++ b/lib/administrate/field/default_search.rb
@@ -1,9 +1,0 @@
-class DefaultSearch
-  def query(table_name, attr_name)
-    "lower(#{table_name}.#{attr_name}) LIKE ?"
-  end
-
-  def search_term(term)
-    "%#{term.downcase}%"
-  end
-end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -21,7 +21,11 @@ module Administrate
       end
 
       def searchable?
-        options.fetch(:searchable, deferred_class.searchable?)
+        !!options.fetch(:searchable, deferred_class.searchable?)
+      end
+
+      def searchable
+        options.fetch(:searchable, deferred_class.searchable)
       end
 
       delegate(

--- a/lib/administrate/field/email.rb
+++ b/lib/administrate/field/email.rb
@@ -6,6 +6,10 @@ module Administrate
       def self.searchable?
         true
       end
+
+      def self.searchable
+        DEFAUT_SEARCH_IMPL
+      end
     end
   end
 end

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -7,6 +7,10 @@ module Administrate
         true
       end
 
+      def self.searchable
+        DEFAUT_SEARCH_IMPL
+      end
+
       def selectable_options
         collection
       end

--- a/lib/administrate/field/string.rb
+++ b/lib/administrate/field/string.rb
@@ -7,6 +7,10 @@ module Administrate
         true
       end
 
+      def self.searchable
+        DEFAUT_SEARCH_IMPL
+      end
+
       def truncate
         data.to_s[0...truncation_length]
       end

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -3,13 +3,79 @@ require "active_support/core_ext/object/blank"
 
 module Administrate
   class Search
+    class SearchStrategy
+      def initialize(resource_class, search_attributes, term)
+        @search_attributes, @term = search_attributes, term
+        @table_name = ActiveRecord::Base.connection.quote_table_name(resource_class.table_name)
+      end
+
+      def attr_name(name)
+        ActiveRecord::Base.connection.quote_column_name(name)
+      end
+    end
+
+    class NilSearchStrategy < SearchStrategy
+      def blank?
+        true
+      end
+    end
+
+    class StringBasedSearchStrategy < SearchStrategy
+      def blank?
+        false
+      end
+
+      def query
+        @search_attributes.map do |name, attr|
+          attr.searchable.query(@table_name, attr_name(name))
+        end.join(" OR ")
+      end
+
+      def search_terms
+        @search_attributes.map do |_name, attr|
+          attr.searchable.search_term(@term.mb_chars)
+        end.flatten
+      end
+    end
+
+    class HashBasedSearchStrategy < SearchStrategy
+      def blank?
+        query.blank?
+      end
+
+      def query
+        @search_attributes.map do |name, attr|
+          next unless @term.has_key?(name) || @term.has_key?(:all)
+          attr.searchable.query(@table_name, attr_name(name))
+        end.compact.join(" #{@term.fetch(:op, 'OR').upcase} ")
+      end
+
+      def search_terms
+        @search_attributes.map do |name, attr|
+          term = @term[name] || @term[:all]
+          next if term.blank?
+          attr.searchable.search_term(term.is_a?(String) ? term.mb_chars : term)
+        end.flatten.compact
+      end
+    end
+
     def initialize(resolver, term)
       @resolver = resolver
       @term = term
+      if term.is_a?(String)
+        search_strategy_cls = StringBasedSearchStrategy
+      elsif term.is_a?(Hash)
+        search_strategy_cls = HashBasedSearchStrategy
+      elsif term.nil?
+        search_strategy_cls = NilSearchStrategy
+      else
+        raise ArgumentError, "cannot determine search strategy for a #{term.class}"
+      end
+      @search_strategy = search_strategy_cls.new(resource_class, search_attributes, @term)
     end
 
     def run
-      if @term.blank?
+      if @term.blank? || @search_strategy.blank?
         resource_class.all
       else
         resource_class.where(query, *search_terms)
@@ -19,21 +85,7 @@ module Administrate
     private
 
     delegate :resource_class, to: :resolver
-
-    def query
-      search_attributes.map do |name, attr|
-        table_name = ActiveRecord::Base.connection.
-          quote_table_name(resource_class.table_name)
-        attr_name = ActiveRecord::Base.connection.quote_column_name(name)
-        attr.searchable.query(table_name, attr_name)
-      end.join(" OR ")
-    end
-
-    def search_terms
-      search_attributes.map do |_name, attr|
-        attr.searchable.search_term(term.mb_chars)
-      end.flatten
-    end
+    delegate :query, :search_terms, to: :@search_strategy
 
     def search_attributes
       attribute_types.select { |_name, type| type.searchable? }

--- a/lib/administrate/search_term_parser.rb
+++ b/lib/administrate/search_term_parser.rb
@@ -1,0 +1,25 @@
+require 'csv'
+
+module Administrate
+  class SearchTermParser
+    def self.parse(term)
+      all_terms = CSV.parse(term).first
+      return if all_terms.blank?
+
+      all_terms.map.with_object({}) do |tuple, hash|
+        label, term = tuple.split(/:\s+/)
+
+        if term.blank?
+          hash[:all] = label.strip
+        else
+          if hash[label.strip.to_sym].present? && !hash[label.strip.to_sym].is_a?(Array)
+            hash[label.strip.to_sym] = Array(hash[label.strip.to_sym])
+            hash[label.strip.to_sym] << term.strip
+          else
+            hash[label.strip.to_sym] = term.strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/example_app/app/dashboards/line_item_dashboard.rb
+++ b/spec/example_app/app/dashboards/line_item_dashboard.rb
@@ -1,6 +1,38 @@
 require "administrate/base_dashboard"
 
 class LineItemDashboard < Administrate::BaseDashboard
+  class ProductByName
+    def self.query(table_name, _attr_name)
+      subquery = Product.select(:id).where('LOWER("products"."name") LIKE ?').to_sql
+      %Q{#{table_name}."product_id" IN (#{subquery})}
+    end
+
+    def self.search_term(term)
+      "%#{term.downcase}%"
+    end
+  end
+
+  class TotalAtLeast
+    def self.query(table_name, attr_name)
+      subquery = LineItem.select(:order_id).distinct.where('unit_price * quantity > ?').to_sql
+      %Q{#{table_name}."order_id" IN (#{subquery})}
+    end
+
+    def self.search_term(term)
+      term.scan(/\d+/).first.to_i
+    end
+  end
+
+  class UnitPriceAtLeast
+    def self.query(table_name, attr_name)
+      "#{table_name}.#{attr_name} >= ?"
+    end
+
+    def self.search_term(term)
+      term.scan(/\d+/).first.to_i
+    end
+  end
+
   ATTRIBUTES = [
     :order,
     :product,
@@ -12,10 +44,10 @@ class LineItemDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     order: Field::BelongsTo,
-    product: Field::BelongsTo,
+    product: Field::BelongsTo.with_options(searchable: ProductByName),
     quantity: Field::Number,
-    total_price: Field::Number.with_options(prefix: "$", decimals: 2),
-    unit_price: Field::Number.with_options(prefix: "$", decimals: 2),
+    total_price: Field::Number.with_options(searchable: TotalAtLeast, prefix: "$", decimals: 2),
+    unit_price: Field::Number.with_options(searchable: UnitPriceAtLeast, prefix: "$", decimals: 2),
   }
 
   COLLECTION_ATTRIBUTES = ATTRIBUTES + [:total_price]

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -1,6 +1,17 @@
 require "administrate/base_dashboard"
 
 class OrderDashboard < Administrate::BaseDashboard
+  class TotalAtLeast
+    def self.query(table_name, attr_name)
+      subquery = LineItem.select(:order_id).distinct.where('unit_price * quantity > ?').to_sql
+      %Q{#{table_name}."id" IN (#{subquery})}
+    end
+
+    def self.search_term(term)
+      term.scan(/\d+/).first.to_i
+    end
+  end
+
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     created_at: Field::DateTime,
@@ -12,7 +23,7 @@ class OrderDashboard < Administrate::BaseDashboard
     address_zip: Field::String,
     customer: Field::BelongsTo,
     line_items: Field::HasMany,
-    total_price: Field::Number.with_options(prefix: "$", decimals: 2),
+    total_price: Field::Number.with_options(searchable: TotalAtLeast, prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
     payments: Field::HasMany,
   }

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -5,40 +5,40 @@ require "administrate/field/email"
 require "administrate/field/number"
 require "administrate/field/date_time"
 require "administrate/search"
+require "administrate/default_search"
 
-class MockUppercaseSearch
-  def query(table_name, attr_name)
+class MockUppercaseSearch < DefaultSearch
+  def build_query(table_name, attr_name)
     "upper(#{table_name}.#{attr_name}) LIKE ?"
   end
 
-  def search_term(term)
+  def build_search_value(term)
     "%#{term.upcase}%"
   end
 end
 
-class MockNumberSearch
-  def query(table_name, attr_name)
+class MockNumberSearch < DefaultSearch
+  def build_query(table_name, attr_name)
     "#{table_name}.#{attr_name} >= ?"
   end
 
-  def search_term(term)
+  def build_search_value(term)
     term.scan(/\d+/).first.to_i
   end
 end
 
-class MockDateTimeSearch
-  def query(table_name, attr_name)
-    "(#{table_name}.#{attr_name}::DATE BETWEEN "\
-      "(date_trunc('day', now()::date - interval '? day')) "\
-      "AND (date_trunc('day', now()::date + interval '? day')))"
-  end
-
+class MockDateTimeSearch < DefaultSearch
   def query(table_name, attr_name)
     "(#{table_name}.#{attr_name}::DATE BETWEEN days_ago(?) AND days_from(?))"
   end
 
-  def search_term(term)
-    [term.scan(/\d+/).first.to_i] * 2
+  def search_term
+    if !@term.is_a?(Array) || @term.size < 2
+      term = [@term, @term].flatten
+    else
+      term = @term
+    end
+    term.map { |e| e.scan(/\d+/).first.to_i }
   end
 end
 
@@ -53,17 +53,17 @@ end
 class MockDashboardWithCustomSearches
   ATTRIBUTE_TYPES = {
     name: Administrate::Field::String,
-    email: Administrate::Field::Email.with_options(searchable: MockUppercaseSearch.new),
-    age: Administrate::Field::Number.with_options(searchable: MockNumberSearch.new),
-    a_date: Administrate::Field::DateTime.with_options(searchable: MockDateTimeSearch.new),
+    email: Administrate::Field::Email.with_options(searchable: MockUppercaseSearch),
+    age: Administrate::Field::Number.with_options(searchable: MockNumberSearch),
+    a_date: Administrate::Field::DateTime.with_options(searchable: MockDateTimeSearch),
   }
 end
 
-describe Administrate::Search do
+describe Administrate::Search, searching: true do
   describe "#run" do
     it "returns all records when no search term" do
       begin
-        class User; end
+        class User < ActiveRecord::Base; end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, nil)
         expect(User).to receive(:all)
@@ -76,7 +76,7 @@ describe Administrate::Search do
 
     it "returns all records when search is empty" do
       begin
-        class User; end
+        class User < ActiveRecord::Base; end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, "   ")
         expect(User).to receive(:all)
@@ -87,14 +87,14 @@ describe Administrate::Search do
       end
     end
 
-    it "searches using lower() + LIKE for all searchable fields" do
+    it "searches using LOWER() + LIKE for all searchable fields" do
       begin
         class User < ActiveRecord::Base; end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, "test")
         expected_query = [
-          "lower(\"users\".\"name\") LIKE ?"\
-          " OR lower(\"users\".\"email\") LIKE ?",
+          "LOWER(\"users\".\"name\") LIKE ?"\
+          " OR LOWER(\"users\".\"email\") LIKE ?",
           "%test%",
           "%test%",
         ]
@@ -106,14 +106,14 @@ describe Administrate::Search do
       end
     end
 
-    it "converts search term lower case for latin and cyrillic strings" do
+    it "converts search term LOWER case for latin and cyrillic strings" do
       begin
         class User < ActiveRecord::Base; end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, "Тест Test")
         expected_query = [
-          "lower(\"users\".\"name\") LIKE ?"\
-          " OR lower(\"users\".\"email\") LIKE ?",
+          "LOWER(\"users\".\"name\") LIKE ?"\
+          " OR LOWER(\"users\".\"email\") LIKE ?",
           "%тест test%",
           "%тест test%",
         ]
@@ -135,7 +135,7 @@ describe Administrate::Search do
           resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
           search = Administrate::Search.new(resolver, "Test")
           expected_query = [
-            "lower(\"users\".\"name\") LIKE ?"\
+            "LOWER(\"users\".\"name\") LIKE ?"\
             " OR upper(\"users\".\"email\") LIKE ?"\
             " OR \"users\".\"age\" >= ?"\
             " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
@@ -159,7 +159,7 @@ describe Administrate::Search do
           resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
           search = Administrate::Search.new(resolver, "4 Бэта Test")
           expected_query = [
-            "lower(\"users\".\"name\") LIKE ?"\
+            "LOWER(\"users\".\"name\") LIKE ?"\
             " OR upper(\"users\".\"email\") LIKE ?"\
             " OR \"users\".\"age\" >= ?"\
             " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
@@ -222,7 +222,7 @@ describe Administrate::Search do
             resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
             search = Administrate::Search.new(resolver, all: "Бэта Test")
             expected_query = [
-              "lower(\"users\".\"name\") LIKE ?"\
+              "LOWER(\"users\".\"name\") LIKE ?"\
               " OR upper(\"users\".\"email\") LIKE ?"\
               " OR \"users\".\"age\" >= ?"\
               " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
@@ -231,6 +231,79 @@ describe Administrate::Search do
               0,
               0,
               0,
+            ]
+            expect(User).to receive(:where).with(*expected_query)
+
+            search.run
+          ensure
+            remove_constants :User
+          end
+        end
+
+        it "uses a specific label value instead of using the special 'all' label" do
+          begin
+            class User < ActiveRecord::Base; end
+            resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
+            search = Administrate::Search.new(resolver, all: "Бэта Test", age: '19')
+            expected_query = [
+              "LOWER(\"users\".\"name\") LIKE ?"\
+              " OR upper(\"users\".\"email\") LIKE ?"\
+              " OR \"users\".\"age\" >= ?"\
+              " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
+              "%бэта test%",
+              "%БЭТА TEST%",
+              19,
+              0,
+              0,
+            ]
+            expect(User).to receive(:where).with(*expected_query)
+
+            search.run
+          ensure
+            remove_constants :User
+          end
+        end
+
+        it "supports multiple values per label" do
+          begin
+            class User < ActiveRecord::Base; end
+            resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
+            search = Administrate::Search.new(resolver, age: %w{3 7 11 13})
+            expected_query = [
+              "\"users\".\"age\" >= ?"\
+              " OR \"users\".\"age\" >= ?"\
+              " OR \"users\".\"age\" >= ?"\
+              " OR \"users\".\"age\" >= ?",
+              3,
+              7,
+              11,
+              13,
+            ]
+            expect(User).to receive(:where).with(*expected_query)
+
+            search.run
+          ensure
+            remove_constants :User
+          end
+        end
+
+        it "handles complex cases" do
+          begin
+            class User < ActiveRecord::Base; end
+            resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
+            search = Administrate::Search.new(resolver, a_date: %w{10 20}, all: "Бэта Test", age: %w{23 19})
+            expected_query = [
+              "LOWER(\"users\".\"name\") LIKE ?"\
+              " OR upper(\"users\".\"email\") LIKE ?"\
+              " OR \"users\".\"age\" >= ?"\
+              " OR \"users\".\"age\" >= ?"\
+              " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
+              "%бэта test%",
+              "%БЭТА TEST%",
+              23,
+              19,
+              10,
+              20,
             ]
             expect(User).to receive(:where).with(*expected_query)
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -3,13 +3,59 @@ require "support/constant_helpers"
 require "administrate/field/string"
 require "administrate/field/email"
 require "administrate/field/number"
+require "administrate/field/date_time"
 require "administrate/search"
+
+class MockUppercaseSearch
+  def query(table_name, attr_name)
+    "upper(#{table_name}.#{attr_name}) LIKE ?"
+  end
+
+  def search_term(term)
+    "%#{term.upcase}%"
+  end
+end
+
+class MockNumberSearch
+  def query(table_name, attr_name)
+    "#{table_name}.#{attr_name} >= ?"
+  end
+
+  def search_term(term)
+    term.scan(/\d+/).first.to_i
+  end
+end
+
+class MockDateTimeSearch
+  def query(table_name, attr_name)
+    "(#{table_name}.#{attr_name}::DATE BETWEEN "\
+      "(date_trunc('day', now()::date - interval '? day')) "\
+      "AND (date_trunc('day', now()::date + interval '? day')))"
+  end
+
+  def query(table_name, attr_name)
+    "(#{table_name}.#{attr_name}::DATE BETWEEN days_ago(?) AND days_from(?))"
+  end
+
+  def search_term(term)
+    [term.scan(/\d+/).first.to_i] * 2
+  end
+end
 
 class MockDashboard
   ATTRIBUTE_TYPES = {
     name: Administrate::Field::String,
     email: Administrate::Field::Email,
     phone: Administrate::Field::Number,
+  }
+end
+
+class MockDashboardWithCustomSearches
+  ATTRIBUTE_TYPES = {
+    name: Administrate::Field::String,
+    email: Administrate::Field::Email.with_options(searchable: MockUppercaseSearch.new),
+    age: Administrate::Field::Number.with_options(searchable: MockNumberSearch.new),
+    a_date: Administrate::Field::DateTime.with_options(searchable: MockDateTimeSearch.new),
   }
 end
 
@@ -76,6 +122,59 @@ describe Administrate::Search do
         search.run
       ensure
         remove_constants :User
+      end
+    end
+
+    context 'with custom searchable definitions', custom_search: true do
+      let(:date_search_lower) { "days_ago(?)" }
+      let(:date_search_upper) { "days_from(?)" }
+
+      it "searches default and custom search implementations" do
+        begin
+          class User < ActiveRecord::Base; end
+          resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
+          search = Administrate::Search.new(resolver, "Test")
+          expected_query = [
+            "lower(\"users\".\"name\") LIKE ?"\
+            " OR upper(\"users\".\"email\") LIKE ?"\
+            " OR \"users\".\"age\" >= ?"\
+            " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
+            "%test%",
+            "%TEST%",
+            0,
+            0,
+            0,
+          ]
+          expect(User).to receive(:where).with(*expected_query)
+
+          search.run
+        ensure
+          remove_constants :User
+        end
+      end
+
+      it "converts search terms in default and custom searches" do
+        begin
+          class User < ActiveRecord::Base; end
+          resolver = double(resource_class: User, dashboard_class: MockDashboardWithCustomSearches)
+          search = Administrate::Search.new(resolver, "4 Бэта Test")
+          expected_query = [
+            "lower(\"users\".\"name\") LIKE ?"\
+            " OR upper(\"users\".\"email\") LIKE ?"\
+            " OR \"users\".\"age\" >= ?"\
+            " OR (\"users\".\"a_date\"::DATE BETWEEN #{date_search_lower} AND #{date_search_upper})",
+            "%4 бэта test%",
+            "%4 БЭТА TEST%",
+            4,
+            4,
+            4,
+          ]
+          expect(User).to receive(:where).with(*expected_query)
+
+          search.run
+        ensure
+          remove_constants :User
+        end
       end
     end
   end

--- a/spec/lib/administrate/search_term_parser_spec.rb
+++ b/spec/lib/administrate/search_term_parser_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require "administrate/search_term_parser"
+
+describe Administrate::SearchTermParser, searching: true do
+  describe '.parse' do
+    it 'returns the string as a search term for all search terms' do
+      expect(described_class.parse 'foobar').to eq all: 'foobar'
+    end
+
+    it 'does not "interpret" search terms' do
+      expect(described_class.parse '23').to eq all: '23'
+    end
+
+    it 'returns the labeled search term' do
+      expect(described_class.parse 'foo: bar').to eq foo: 'bar'
+    end
+
+    it 'returns the labeled search term and an "all" search term' do
+      expect(described_class.parse 'foo: bar, baz').to eq foo: 'bar', all: 'baz'
+    end
+
+    it 'returns the labeled search terms' do
+      expect(described_class.parse 'foo: bar, baz: blat').to eq foo: 'bar', baz: 'blat'
+    end
+
+    it 'converts multiple occurrences of a labeled search term into an array of terms' do
+      expect(described_class.parse 'foo: bar, foo: blat').to eq foo: %w[bar blat]
+    end
+  end
+end

--- a/spec/lib/administrate/search_term_parser_spec.rb
+++ b/spec/lib/administrate/search_term_parser_spec.rb
@@ -26,5 +26,9 @@ describe Administrate::SearchTermParser, searching: true do
     it 'converts multiple occurrences of a labeled search term into an array of terms' do
       expect(described_class.parse 'foo: bar, foo: blat').to eq foo: %w[bar blat]
     end
+
+    it 'can create an arrayed search term from the "all" label' do
+      expect(described_class.parse 'all: foo, all: bar, year: 2014').to eq all: %w[foo bar], year: '2014'
+    end
   end
 end


### PR DESCRIPTION
This PR adds a pluggable search feature to Administrate. Instead of a simple boolean, `searchable` can now also take a class that implements `#query/2`, `#search_term`, and `#with_context/1`. There is a [`DefaultSearch`](https://github.com/upper-hand/administrate/blob/make-search-pluggable/lib/administrate/default_search.rb) implementation that other searches can extend.


### Usage
Searches can be labeled with their attribute or, without an attribute, they will be grouped in the "special" `:all` label that will be run against any searchable attribute. Labeled searches will always be preferred to the `:all` label. In addition, labels can be specified more than once to enable searching for multiple values within the attribute. Finally, "op: and" can be used to turn the default "OR" operator to an "AND" operator when creating the outer query conditions (multiple occurrences of a labeled search will always use an "OR" search unless overridden by the search definition).

### Examples:
  On the Line Items page of the same application this search will find
  all line items which are either for The Game of Life product, have a
  unit price greater than or equal to $63.00, or whose order comes to
  a total price greater than or equal to $190.00.

    `product: Game of Life, unit_price: 63, total_price: 190`

  This search is similar to the above but uses "AND" for the outer
  query, and thus requires all of the search terms to be true.

    `op: and, product: Game of Life, unit_price: 63, total_price: 190`